### PR TITLE
Fixed memory leak after closing view

### DIFF
--- a/Sources/MapItemPicker/MapItemPickerSheet.swift
+++ b/Sources/MapItemPicker/MapItemPickerSheet.swift
@@ -14,78 +14,14 @@ import MapKit
 struct MapItemPickerSheet<Content: View>: View {
     
     @Binding var isPresented: Bool
-    
-    @State private var pickerViewController: MapItemPickerViewController
-    
-    private var content: Content
-    
-    private var onDismiss: ((MKMapItem?) -> Void)?
-    
-    init(isPresented: Binding<Bool>, onDismiss: ((MKMapItem?) -> Void)?, content: Content) {
-        let pickerViewController = MapItemPickerViewController()
-        self.onDismiss = onDismiss
-        self._pickerViewController = State(wrappedValue: pickerViewController)
-        self._isPresented = isPresented
-        self.content = content
-        setupPickerViewController()
-    }
-    
-    private func setupPickerViewController() {
-        pickerViewController.onDismiss = { mapItem in
-            onDismiss?(mapItem)
-            isPresented = false
-        }
-    }
+    var onDismiss: ((MKMapItem?) -> Void)?
+    var content: Content
     
     var body: some View {
         content
-            .onChange(of: pickerViewController.isBeingPresented) { presenting in
-                isPresented = presenting
+            .sheet(isPresented: $isPresented) {
+                MapItemPickerView(isPresented: $isPresented, onDismiss: onDismiss)
             }
-            .onChange(of: isPresented) { presenting in
-                if presenting && !pickerViewController.isBeingPresented {
-#if targetEnvironment(macCatalyst)
-                    UIApplication.shared
-                        .topmostViewController?
-                        .present(pickerViewController.searchNavigationController, animated: true)
-#else
-                    UIApplication.shared
-                        .topmostViewController?
-                        .present(pickerViewController, animated: true)
-                    pickerViewController
-                        .present(pickerViewController.searchNavigationController, animated: true)
-#endif
-                } else {
-#if targetEnvironment(macCatalyst)
-                    pickerViewController.searchNavigationController
-                        .presentingViewController?
-                        .dismiss(animated: true)
-#else
-                    pickerViewController
-                        .presentingViewController?
-                        .dismiss(animated: true)
-#endif
-                    pickerViewController = MapItemPickerViewController()
-                    setupPickerViewController()
-                }
-            }
-    }
-}
-
-private extension UIApplication {
-    var topmostViewController: UIViewController? {
-        var viewController = connectedScenes
-            .filter { $0.activationState == .foregroundActive }
-            .compactMap({$0 as? UIWindowScene})
-            .first?
-            .windows
-            .filter { $0.isKeyWindow }
-            .first?
-            .rootViewController
-        while let presentedViewController = viewController?.presentedViewController {
-            viewController = presentedViewController
-        }
-        return viewController
     }
 }
 

--- a/Sources/MapItemPicker/MapItemPickerView.swift
+++ b/Sources/MapItemPicker/MapItemPickerView.swift
@@ -1,0 +1,48 @@
+//
+//  MapItemPickerView.swift
+//  
+//
+//  Created by Oscar Fridh on 2022-10-08.
+//
+
+#if os(iOS)
+
+import SwiftUI
+import MapKit
+
+@available(iOS 15.0, *)
+struct MapItemPickerView: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    var onDismiss: ((MKMapItem?) -> Void)?
+    
+    func makeUIViewController(context: Context) -> MapItemPickerViewController {
+        let vc = MapItemPickerViewController()
+        context.coordinator.setupPickerViewController(vc)
+        return vc
+    }
+    
+    func updateUIViewController(_ uiViewController: MapItemPickerViewController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator {
+        var parent: MapItemPickerView
+        
+        func setupPickerViewController(_ vc: MapItemPickerViewController) {
+            vc.onDismiss = { [unowned self, unowned vc] mapItem in
+                vc.dismiss(animated: true) {
+                    self.parent.isPresented = false
+                    self.parent.onDismiss?(mapItem)
+                }
+            }
+        }
+        
+        init(_ parent: MapItemPickerView) {
+            self.parent = parent
+        }
+    }
+}
+
+#endif

--- a/Sources/MapItemPicker/MapItemPickerViewController.swift
+++ b/Sources/MapItemPicker/MapItemPickerViewController.swift
@@ -199,6 +199,8 @@ class MapItemPickerViewController:
             self.locationManager.requestWhenInUseAuthorization()
         })
         locationManager.requestWhenInUseAuthorization()
+        
+        present(searchNavigationController, animated: true)
     }
     
     private lazy var mapView: MKMapView = {

--- a/Sources/MapItemPicker/MapItemPickerViewController.swift
+++ b/Sources/MapItemPicker/MapItemPickerViewController.swift
@@ -49,7 +49,8 @@ class MapItemPickerViewController:
     private lazy var searchCompletionsTableViewController: SearchCompletionsTableViewController = {
         let tableViewController = SearchCompletionsTableViewController(style: .plain)
         tableViewController.searchRegion = searchRegion
-        tableViewController.onCompletionSelection = { completion in
+        tableViewController.onCompletionSelection = { [weak self] completion in
+            guard let self else { return }
             self.searchResponseTableViewController.tableView.isHidden = false
             self.searchController.isActive = false
             self.searchController.searchBar.text = nil //[completion.title, completion.subtitle].joined(separator: ", ")
@@ -64,8 +65,8 @@ class MapItemPickerViewController:
             let searchRequest = MKLocalSearch.Request(completion: completion)
             searchRequest.region = self.searchRegion
             let search = MKLocalSearch(request: searchRequest)
-            search.start { (response, error) in
-                self.searchResponse = response
+            search.start { [weak self] (response, error) in
+                self?.searchResponse = response
             }
         }
         
@@ -80,7 +81,8 @@ class MapItemPickerViewController:
     
     private lazy var searchResponseTableViewController: SearchResponseTableViewController = {
         let tableViewController = SearchResponseTableViewController(style: .insetGrouped)
-        tableViewController.onMapItemSelection = { mapItemIndex in
+        tableViewController.onMapItemSelection = { [weak self] mapItemIndex in
+            guard let self else { return }
             self.selectedAnnotationIndex = mapItemIndex
             let annotation = self.annotations[mapItemIndex]
             if !self.mapView.annotations(in: self.mapView.visibleMapRect).contains(annotation as! AnyHashable) {
@@ -99,7 +101,8 @@ class MapItemPickerViewController:
         tableViewController.tableView.backgroundView = blurEffectView
         tableViewController.tableView.separatorEffect = UIVibrancyEffect(blurEffect: blurEffect)
         
-        tableViewController.onViewWillLayoutSubviews = {
+        tableViewController.onViewWillLayoutSubviews = { [weak self] in
+            guard let self else { return }
             self.mapView.frame = self.view.bounds
             let bottomMargin: CGFloat
             if UIDevice.current.userInterfaceIdiom == .pad {
@@ -115,14 +118,15 @@ class MapItemPickerViewController:
     }()
     
     private lazy var cancelButton: UIBarButtonItem = {
-        let cancelAction = UIAction { _ in
-            self.onDismiss?(nil)
+        let cancelAction = UIAction { [weak self] _ in
+            self?.onDismiss?(nil)
         }
         return UIBarButtonItem(systemItem: .cancel, primaryAction: cancelAction, menu: nil)
     }()
     
     private lazy var selectionButton: UIBarButtonItem = {
-        let selectionAction = UIAction { _ in
+        let selectionAction = UIAction { [weak self] _ in
+            guard let self else { return }
             if
                 let index = self.selectedAnnotationIndex,
                 let response = self.searchResponse?.mapItems[index]
@@ -227,8 +231,8 @@ class MapItemPickerViewController:
         searchRequest.region =  searchRegion
         searchRequest.naturalLanguageQuery = text
         let search = MKLocalSearch(request: searchRequest)
-        search.start { (response, error) in
-            self.searchResponse = response
+        search.start { [weak self] (response, error) in
+            self?.searchResponse = response
         }
     }
     

--- a/Sources/MapItemPicker/MapItemPickerViewController.swift
+++ b/Sources/MapItemPicker/MapItemPickerViewController.swift
@@ -33,7 +33,9 @@ class MapItemPickerViewController:
         searchNavigationController.presentationController?.delegate = self
         if let sheet = searchNavigationController.sheetPresentationController {
 #if !targetEnvironment(macCatalyst)
-            sheet.prefersGrabberVisible = true
+            // Work-around to avoid memory leak.
+            // The grabber causes a _UIPageSheetPresentationController to prevent the presented view controller from being released after being dismissed.
+            //sheet.prefersGrabberVisible = true
 #endif
             sheet.delegate = self
             sheet.detents = [.medium(), .large()]


### PR DESCRIPTION
This PR fixes memory leaks as mentioned in issue #1.

- Fixed closure retain cycles,
- Rewrote presentation of MapItemPickerViewController to prevent the view controllers from retaining each other,
- Avoided what appears to be a bug in UIKit by hiding the grabber. I have submitted a bug report to Apple and hopefully, it will be fixed soon. Maybe the [presentationDetents](https://developer.apple.com/documentation/charts/chart/presentationdetents(_:)) modifier (which does not leak) could be used as a workaround, but that would require iOS 16 and more changes.

**before**

<img width="437" alt="before" src="https://user-images.githubusercontent.com/25850923/194723927-dc2f91f6-dd9b-4a08-8e69-6063d3459521.png">

**after**

<img width="522" alt="after" src="https://user-images.githubusercontent.com/25850923/194723937-81289841-3481-4650-b7b0-ea85de45410f.png">

Please let me know if you have any feedback. And again, thank you for a really cool package! :)

